### PR TITLE
Updating a broken dependency

### DIFF
--- a/example/elm.json
+++ b/example/elm.json
@@ -6,18 +6,18 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-			"cedric-h/elm-google-sign-in": "2.0.0",
+			      "cedric-h/elm-google-sign-in": "2.0.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
-            "rtfeldman/elm-css": "16.0.1"
+            "rtfeldman/elm-css": "18.0.0"
         },
         "indirect": {
-            "Skinney/murmur3": "2.0.8",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
+            "elm/virtual-dom": "1.0.3",
+            "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0"
         }
     },


### PR DESCRIPTION
`Skinney/murmur3` is now `robinheghan/murmur3`, and `Skinney/murmur3` is broken (`rtfeldman/elm-css 16.0.1` uses the skinney version).

See this commit for details on the name change: https://github.com/robinheghan/murmur3/commit/ec218ceddae5185d01e7eda33f1cb715da045671

And this issue explaining the problem: https://github.com/elm/compiler/issues/2293

I didn't test this exact code because I don't want to use npm/node, but it seems to be working in my fork: https://github.com/jxlxx/elm-google-sign-in.

Let me know if you see any issues :) 
